### PR TITLE
Add additional_fields option

### DIFF
--- a/lib/render_json_rails/helper.rb
+++ b/lib/render_json_rails/helper.rb
@@ -32,7 +32,8 @@ module RenderJsonRails
         includes: includes,
         fields: params[:fields],
         override_render_json_config: override_render_json_config,
-        additional_config: additional_config
+        additional_config: additional_config,
+        additional_fields: params[:additional_fields]
       )
       if params[:formatted] && !Rails.env.development? || params[:formatted] != 'no' && Rails.env.development?
         json = JSON.pretty_generate(object.as_json(options))

--- a/test/render_json_rails_test.rb
+++ b/test/render_json_rails_test.rb
@@ -169,7 +169,27 @@ class RenderJsonRailsTest < Minitest::Test
         default_fields: [:calculated0, :id, :email],
       }
     )
-    expected = { only: [:id, :email], methods: [:calculated0] }
+    expected = { only: [:id, :email] }
+    assert_equal expected, out, "out: #{out}"
+  end
+
+  def test_additional_fields
+    out = DefaultFieldsModel.render_json_options(
+      additional_fields: { "default_fields_model" => "account_id,number,calculated2" }
+    )
+    expected = { only: [:id, :name, :number], methods: [:calculated1, :calculated2] }
+    assert_equal expected, out, "out: #{out}"
+
+    out = TestModel1.render_json_options(
+      additional_fields: { "model1" => "calculated0" }
+    )
+    expected = { except: [:account_id], methods: [:calculated0] }
+    assert_equal expected, out, "out: #{out}"
+
+    out = DefaultFieldsModelWithOnly.render_json_options(
+      additional_fields: {"default_fields_model_with_only" => "calculated2"}
+    )
+    expected = { only: [:id, :name], methods: [:calculated1, :calculated2] }
     assert_equal expected, out, "out: #{out}"
   end
 end


### PR DESCRIPTION
Opcja additional_fields:
- w przypadku korzystania z default_fields, możliwość wyświetlenia dodatkowo pól niewymienionych w except oraz metod z allowed_methods
- wpp., możliwość wyświetlenia wymienionych metod z allowed_methods oprócz domyślnych metod i pól

TODO:
- [ ] opis w README.md