### PR TITLE
Except in additional config improv

### DIFF
--- a/lib/render_json_rails/concern.rb
+++ b/lib/render_json_rails/concern.rb
@@ -74,11 +74,17 @@ module RenderJsonRails
           fields[name] = current_json_config[:default_fields].join(',')
         end
 
+        if additional_config && additional_config[:except]
+          except = RenderJsonRails::Concern.meld(current_json_config[:except], additional_config[:except])
+        else
+          except = current_json_config[:except]
+        end
+
         options = default_json_options(
           name: name,
           fields: fields,
           only: current_json_config[:only],
-          except: current_json_config[:except],
+          except: except,
           methods: current_json_config[:methods],
           allowed_methods: current_json_config[:allowed_methods],
           additional_fields: additional_fields
@@ -110,19 +116,23 @@ module RenderJsonRails
       includes.find_all { |el| el.present? }
     end
 
+    def self.meld(val1, val2)
+      if !val1.nil? && val2 == nil
+        val1
+      elsif val1 == nil && !val2.nil?
+        val2
+      elsif val1.is_a?(Array) && val2.is_a?(Array)
+        val1 | val2
+      elsif val1.is_a?(Hash) && val2.is_a?(Hash)
+        deep_meld(val1, val2)
+      else
+        [val1, val2]
+      end
+    end
+
     def self.deep_meld(hh1, hh2)
       hh1.deep_merge(hh2) do |_key, this_val, other_val|
-        if !this_val.nil? && other_val == nil
-          this_val
-        elsif this_val == nil && !other_val.nil?
-          other_val
-        elsif this_val.is_a?(Array) && other_val.is_a?(Array)
-          this_val | other_val
-        elsif this_val.is_a?(Hash) && other_val.is_a?(Hash)
-          deep_meld(this_val, other_val)
-        else
-          [this_val, other_val]
-        end
+        self.meld(this_val, other_val)
       end
     end
   end

--- a/lib/render_json_rails/version.rb
+++ b/lib/render_json_rails/version.rb
@@ -1,3 +1,3 @@
 module RenderJsonRails
-  VERSION = "0.2.4"
+  VERSION = "0.2.5"
 end

--- a/render_json_rails.gemspec
+++ b/render_json_rails.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Marcin"]
   spec.email         = ["marcin@radgost.com"]
 
-  spec.summary       = "Simle JSON API render like JonApi"
+  spec.summary       = "Simple JSON API render like JsonApi"
   spec.description   = "render json with 'includes' and 'fields' with simple config"
   spec.homepage      = "https://github.com/intum/render_json_rails"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")

--- a/test/render_json_rails_test.rb
+++ b/test/render_json_rails_test.rb
@@ -238,4 +238,18 @@ class RenderJsonRailsTest < Minitest::Test
     }
     assert_equal expected, out, "out: #{out}"
   end
+
+  def test_except_in_additional_config_should_work_on_methods
+    out = DefaultFieldsModel.render_json_options
+    expected = { only: [:id, :name], methods: [:calculated1] }
+    assert_equal expected, out, "out: #{out}"
+
+    out = DefaultFieldsModel.render_json_options(
+      additional_config: {
+        except: [:calculated1]
+      }
+    )
+    expected = { only: [:id, :name], except: [:calculated1] }
+    assert_equal expected, out, "out: #{out}"
+  end
 end


### PR DESCRIPTION
Przekazanie nazw metod do addtional_config[:except] nie wpływało na wykluczenie ich z rendera.